### PR TITLE
Build script: don't run "mono dotnet" on macOS/Linux

### DIFF
--- a/fcs/build.fsx
+++ b/fcs/build.fsx
@@ -33,6 +33,13 @@ let runCmdIn workDir (exe:string) = Printf.ksprintf (fun (args:string) ->
         |> assertExitCodeZero
 )
 
+let runDotnet workDir = Printf.ksprintf (fun (args:string) ->
+    printfn "[%s] dotnet %s" workDir args
+    Shell.Exec("dotnet", args, workDir)
+    |> assertExitCodeZero
+)
+
+
 // --------------------------------------------------------------------------------------
 // The rest of the code is standard F# build script
 // --------------------------------------------------------------------------------------
@@ -124,12 +131,12 @@ let isDotnetSDKInstalled =
 
 Target "CodeGen.Fable" (fun _ ->
     // run standard FCS codegen
-    runCmdIn __SOURCE_DIRECTORY__  "dotnet" "build %s" "./fcs-fable/codegen/codegen.fsproj"
+    runDotnet __SOURCE_DIRECTORY__  "build %s" "./fcs-fable/codegen/codegen.fsproj"
 
     // Fable-specific (running fssrgen without .resx output to inline it)
     let outDir = "./fcs-fable/codegen"
-    runCmdIn __SOURCE_DIRECTORY__  "dotnet" "fssrgen ../src/fsharp/FSComp.txt %s/FSComp.fs" outDir
-    runCmdIn __SOURCE_DIRECTORY__  "dotnet" "fssrgen ../src/fsharp/fsi/FSIstrings.txt %s/FSIstrings.fs" outDir
+    runDotnet __SOURCE_DIRECTORY__  "fssrgen ../src/fsharp/FSComp.txt %s/FSComp.fs" outDir
+    runDotnet __SOURCE_DIRECTORY__  "fssrgen ../src/fsharp/fsi/FSIstrings.txt %s/FSIstrings.fs" outDir
 
     // Fable-specific (comment the #line directive as it is not supported)
     ["lex.fs"; "pplex.fs"; "illex.fs"; "ilpars.fs"; "pars.fs"; "pppars.fs"]
@@ -138,12 +145,12 @@ Target "CodeGen.Fable" (fun _ ->
 )
 
 Target "Build.NetStd" (fun _ ->
-    runCmdIn __SOURCE_DIRECTORY__  "dotnet" "pack %s -v n -c Release" "FSharp.Compiler.Service.netstandard.sln"
+    runDotnet __SOURCE_DIRECTORY__  "pack %s -v n -c Release" "FSharp.Compiler.Service.netstandard.sln"
 )
 
 
 Target "Test.NetStd" (fun _ ->
-    runCmdIn __SOURCE_DIRECTORY__  "dotnet" "run -p FSharp.Compiler.Service.Tests.netcore/FSharp.Compiler.Service.Tests.netcore.fsproj -c Release -- --result:TestResults.NetStd.xml;format=nunit3"
+    runDotnet __SOURCE_DIRECTORY__  "run -p FSharp.Compiler.Service.Tests.netcore/FSharp.Compiler.Service.Tests.netcore.fsproj -c Release -- --result:TestResults.NetStd.xml;format=nunit3"
 )
 
 
@@ -151,7 +158,7 @@ Target "Test.NetStd" (fun _ ->
 Target "Nuget.AddNetStd" (fun _ ->
     let nupkg = sprintf "%s/FSharp.Compiler.Service.%s.nupkg" releaseDir release.AssemblyVersion
     let netcoreNupkg = sprintf "FSharp.Compiler.Service.netstandard/bin/Release/FSharp.Compiler.Service.%s.nupkg" release.AssemblyVersion
-    runCmdIn __SOURCE_DIRECTORY__ "dotnet" "mergenupkg --source %s --other %s --framework netstandard1.6" nupkg netcoreNupkg
+    runDotnet __SOURCE_DIRECTORY__ "mergenupkg --source %s --other %s --framework netstandard1.6" nupkg netcoreNupkg
 )
 
 


### PR DESCRIPTION
This is always biting me when running build CodeGen on macOS ;)