### PR TITLE
Fable nuget config

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="NuGet.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+  <disabledPackageSources>
+     <clear />
+  </disabledPackageSources>
+</configuration>


### PR DESCRIPTION
This PR add the NuGet.Config file need for some people on Windows. Without it I can't build the repo paket/dotnet is messing up with the the global config and a `NugetFallbackFolder` error