### PR TITLE
Export metadata in project repo not to the root of the system

### DIFF
--- a/src/fsharp/CompileOps.fs
+++ b/src/fsharp/CompileOps.fs
@@ -4774,7 +4774,7 @@ type TcImports(tcConfigP:TcConfigProvider, initialResolutions:TcAssemblyResoluti
         frameworkTcImports.SetTcGlobals(tcGlobals)
 
 #if EXPORT_METADATA
-        let metadataPath = "/temp/metadata2/"
+        let metadataPath = __SOURCE_DIRECTORY__ + "/../../temp/metadata2/"
         let writeMetadata (dllInfo: ImportedBinary) =
             let outfile = Path.GetFullPath(metadataPath + Path.GetFileName(dllInfo.FileName))
             let ilModule = dllInfo.RawMetadata.TryGetRawILModule().Value


### PR DESCRIPTION
Current export path is relative to the system root if you use a *nix system and it's failing because we need the root privilege to write their.

With this PR the export path is at the root of the repo.