### PR TITLE
Add Fable.Import.Browser for metadata export

### DIFF
--- a/fcs/fcs-export/fcs-export.fsproj
+++ b/fcs/fcs-export/fcs-export.fsproj
@@ -13,7 +13,7 @@
     <ProjectReference Include="../FSharp.Compiler.Service.netstandard/FSharp.Compiler.Service.netstandard.fsproj" />
     <PackageReference Include="FSharp.Core" Version="4.2.*" PrivateAssets="All" />
     <PackageReference Include="Dotnet.ProjInfo.Matthid" Version="1.0.0" />
-    <PackageReference Include="Fable.Core" Version="1.2.*" />
+    <PackageReference Include="Fable.Core" Version="1.3.*" />
     <PackageReference Include="Fable.Import.Browser" Version="*" />
   </ItemGroup>
 </Project>

--- a/fcs/fcs-export/fcs-export.fsproj
+++ b/fcs/fcs-export/fcs-export.fsproj
@@ -14,5 +14,6 @@
     <PackageReference Include="FSharp.Core" Version="4.2.*" PrivateAssets="All" />
     <PackageReference Include="Dotnet.ProjInfo.Matthid" Version="1.0.0" />
     <PackageReference Include="Fable.Core" Version="1.2.*" />
+    <PackageReference Include="Fable.Import.Browser" Version="*" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fable.Import.Browser isn't anymore in Fable.Core so we need to reference Fable.Import.Browser.dll