### PR TITLE
Use / for linux path

### DIFF
--- a/fcs/fcs-fable/codegen/fssrgen.targets
+++ b/fcs/fcs-fable/codegen/fssrgen.targets
@@ -24,7 +24,7 @@ Copyright (C) Microsoft Corporation. All Rights Reserved.
         Condition="'@(FsSrGen)'!=''">
     <!-- Run the FsSrGen tool (no .resx output to inline it) -->
     <Exec Command="&quot;$([System.IO.Path]::GetFullPath('$(FsiToolPath)\$(FsiToolExe)'))&quot; --exec &quot;$(FSharpSourcesRoot)\scripts\fssrgen.fsx&quot; &quot;%(FsSrGen.FullPath)&quot; &quot;%(FsSrGen.Filename).fs&quot;" Condition="'$(OS)' != 'Unix'" />
-    <Exec Command="mono  $([System.IO.Path]::GetFullPath('$(FsiToolPath)\$(FsiToolExe)'))       --exec &quot;$(FSharpSourcesRoot)\scripts\fssrgen.fsx&quot; &quot;%(FsSrGen.FullPath)&quot; &quot;%(FsSrGen.Filename).fs&quot;" Condition="'$(OS)' == 'Unix'" />
+    <Exec Command="mono  $([System.IO.Path]::GetFullPath('$(FsiToolPath)\$(FsiToolExe)'))       --exec &quot;$(FSharpSourcesRoot)/scripts/fssrgen.fsx&quot; &quot;%(FsSrGen.FullPath)&quot; &quot;%(FsSrGen.Filename).fs&quot;" Condition="'$(OS)' == 'Unix'" />
   </Target>
 
   <ItemGroup>


### PR DESCRIPTION
I don't know why it's needed but from a fresh repo of *fable-repl* I needed to do this changes otherwise the mono command failed because the file isn't found.

Here is the failing path:

`/home/mangelmaxime/Workspaces/temp/FSharp.Compiler.Service_fable/fcs/fcs-fable/codegen/../../../src\scripts\fssrgen.fsx`

As you can see every separator is a `/` except for the two lasts.