### PR TITLE
Keep source hashes through watch compilations

### DIFF
--- a/fcs/FSharp.Compiler.Service/service_slim.fs
+++ b/fcs/FSharp.Compiler.Service/service_slim.fs
@@ -122,6 +122,8 @@ type InteractiveChecker internal (tcConfig, tcGlobals, tcImports, tcInitialState
         parseCache.GetOrAdd(parseCacheKey, fun _ ->
             x.ClearStaleCache(fileName, parsingOptions)
             let parseErrors, parseTreeOpt, anyErrors = Parser.parseFile (source.Value, fileName, parsingOptions, userOpName)
+            let dependencyFiles = [||] // interactions have no dependencies
+            FSharpParseFileResults (parseErrors, parseTreeOpt, anyErrors, dependencyFiles) )
 
     member private x.CheckFile (projectFileName: string, parseResults: FSharpParseFileResults, tcState: TcState, moduleNamesDict: ModuleNamesDict) =
         match parseResults.ParseTree with


### PR DESCRIPTION
@ncave I know you don't want to leak the cache :) but I was getting crashes on my mac when trying to build the REPL (now named fable-standalone to tell it apart from the repl repository) and thought they would be related to memory overuse. Hopefully this should prevent having to load all file sources at once. Also, it allows the client to "cache" the hashes so for watch compilations the unneeded sources can be garbage collected and only the dirty files are read again.

However, I'm still getting the crashes on my mac so it seems to be unrelated. I haven't measured either if this has any performance impact. So for now I'm just sending this as an speculative PR but feel free to discard it if you don't like the solution.